### PR TITLE
Create 80-i2c-noroot.rules

### DIFF
--- a/etc/udev/rules.d/80-i2c-noroot.rules
+++ b/etc/udev/rules.d/80-i2c-noroot.rules
@@ -1,0 +1,6 @@
+# /etc/udev/rules.d/80-i2c-noroot.rules
+#
+SUBSYSTEM=="i2c", GROUP="i2c"
+DRIVER=="*", ACTION=="add", \
+	RUN+="/bin/chgrp -R gpio '/sys%p'", \
+	RUN+="/bin/chmod -R g=u '/sys%p'"                                                                                                                                    


### PR DESCRIPTION
I'm trying to get the new_device file to be writable to be able to enable new I2C devices.